### PR TITLE
Fix code scanning alert no. 1: Type confusion through parameter tampering

### DIFF
--- a/server/src/weather/weather.route.ts
+++ b/server/src/weather/weather.route.ts
@@ -21,15 +21,15 @@ weatherRoutes.get('/', async (req: Request<{}, {}, {}, Query>, res: Response, ne
 
     const {street, zipcode} = req.query;
 
-    if (!street) {
-        errors.push("Must provide a street query parameter");
+    if (typeof street !== 'string') {
+        errors.push("Must provide a valid street query parameter");
     }
 
-    if (!zipcode) {
-        errors.push("Must provide a zipcode query parameter");
+    if (typeof zipcode !== 'string') {
+        errors.push("Must provide a valid zipcode query parameter");
     }
 
-    if (zipcode.length !== 5) {
+    if (zipcode && zipcode.length !== 5) {
         errors.push("Zip code must be 5 characters long");
     }
 


### PR DESCRIPTION
Fixes [https://github.com/spacecostsmoney/react-node-weather/security/code-scanning/1](https://github.com/spacecostsmoney/react-node-weather/security/code-scanning/1)

To fix the problem, we need to ensure that the `zipcode` parameter is of type `string` before performing any operations on it. This can be done by adding a type check for `zipcode` and `street` before using them. If either parameter is not a string, we should add an error message to the `errors` array and handle it accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
